### PR TITLE
Scenario: vNIC Good path - Network device

### DIFF
--- a/config/tests/host/io_vnic_scenario_goodpath.cfg
+++ b/config/tests/host/io_vnic_scenario_goodpath.cfg
@@ -1,0 +1,34 @@
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_add avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_start avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+
+avocado-misc-tests/cpu/ppc64_cpu_test.py:PPC64Test.test_smt_loop
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+
+avocado-misc-tests/cpu/cpustress.py avocado-misc-tests/cpu/cpustress.py.data/cpustress.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+
+avocado-misc-tests/memory/memtester.py avocado-misc-tests/memory/memtester.py.data/memtester.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+
+avocado-misc-tests/io/net/bonding.py:Bonding.test_setup avocado-misc-tests/io/net/bonding.py.data/bonding_single.yaml
+avocado-misc-tests/io/net/bonding.py:Bonding.test_run avocado-misc-tests/io/net/bonding.py.data/bonding_single.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+
+avocado-misc-tests/io/net/network_test.py:NetworkTest.test_gro avocado-misc-tests/io/net/network_test.py.data/network_test_virt_net.yaml
+avocado-misc-tests/io/net/network_test.py:NetworkTest.test_lro avocado-misc-tests/io/net/network_test.py.data/network_test_virt_net.yaml
+avocado-misc-tests/io/net/network_test.py:NetworkTest.test_tso avocado-misc-tests/io/net/network_test.py.data/network_test_virt_net.yaml
+avocado-misc-tests/io/net/network_test.py:NetworkTest.test_promisc avocado-misc-tests/io/net/network_test.py.data/network_test_virt_net.yaml
+
+avocado-misc-tests/io/net/bonding.py:Bonding.test_cleanup avocado-misc-tests/io/net/bonding.py.data/bonding_single.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_stop avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_start avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+
+avocado-misc-tests/io/net/bridge.py avocado-misc-tests/io/net/bridge.py.data/bridge.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_stop avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_remove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml


### PR DESCRIPTION
The cfg is for network scenario_good_path test  and it is created referring RQM scenario_good_path test. Set of test cases covering the cfg are as below
1. htx + smt on/off + ensure CPU affinity is set for all CPUs + irqbalance  ( 1 hr stress and SMT changes in the interval of 1 min)
2. htx + cpustress + memorystress
3. Htx + bond0 + GRO=on/off + LRO=on/off +  promisc=on/off ( 1 hr stress )    
4. Htx + bond4 + GRO=on/off + LRO=on/off +  promisc=on/off ( 1 hr stress )    
5. htx + (no bond) + Network bridge + TSO=on    ( 1 hr stress )  

Signed-off-by: Tasmiya Nalatwad <tasmiya@linux.vnet.ibm.com>