### PR TITLE
removed unsupported vhost_dpdk test

### DIFF
--- a/config/tests/guest/libvirt/network.cfg
+++ b/config/tests/guest/libvirt/network.cfg
@@ -165,6 +165,7 @@ variants:
                 no virtual_network.iface_options.iface_macvtap.driver_vhost.mode_vepa
                 no virtual_network.iface_options.iface_type.type_mcast
                 no virtual_network.iface_options.iface_type.type_user
+                no virtual_network.iface_options.iface_type.type_vhostuser.vhost_dpdk
                 no virtual_network.iface_options.iface_unprivileged_user
             - net_virsh_attach_detach_interface:
                 only virsh.attach_detach_interface

--- a/config/tests/guest/libvirt/regression.cfg
+++ b/config/tests/guest/libvirt/regression.cfg
@@ -169,6 +169,7 @@ variants:
                         no virtual_network.iface_options.iface_source_default
                         no virtual_network.iface_options.iface_type.type_mcast
                         no virtual_network.iface_options.iface_type.type_user
+                        no virtual_network.iface_options.iface_type.type_vhostuser.vhost_dpdk
                         no virtual_network.iface_options.iface_unprivileged_user
                         no virtual_network.iface_options.iface_driver.driver_vhost.error_test
                         no virtual_network.iface_options.iface_driver.driver_vhost.without_vhost_net


### PR DESCRIPTION
vhost_dpdk tests are not supported since libvirt v7.0.0 Hence removing this test from configuration file.

source: https://github.com/autotest/tp-libvirt/commit/fdeed80724c0ca4ce7c60679db4cad3b35a97d4c