### PR TITLE
Updating vNIC and vETH  test bucket.

### DIFF
--- a/config/tests/host/io_veth.cfg
+++ b/config/tests/host/io_veth.cfg
@@ -1,0 +1,18 @@
+avocado-misc-tests/io/common/bootlist_test.py avocado-misc-tests/io/common/bootlist_test.py.data/bootlist_test_network.yaml
+avocado-misc-tests/io/net/ethtool_test.py avocado-misc-tests/io/net/ethtool_test.py.data/ethtool_test.yaml
+avocado-misc-tests/io/net/net_tools.py avocado-misc-tests/io/net/net_tools.py.data/net_tools.yaml
+avocado-misc-tests/io/net/network_test.py avocado-misc-tests/io/net/network_test.py.data/network_test.yaml "--execution-order tests-per-variant"
+avocado-misc-tests/io/net/multicast.py avocado-misc-tests/io/net/multicast.py.data/multicast.yaml
+avocado-misc-tests/io/net/uperf_test.py avocado-misc-tests/io/net/uperf_test.py.data/uperf_test.yaml "--execution-order tests-per-variant"
+avocado-misc-tests/io/net/netperf_test.py avocado-misc-tests/io/net/netperf_test.py.data/netperf_test.yaml "--execution-order tests-per-variant"
+avocado-misc-tests/io/net/tcpdump.py avocado-misc-tests/io/net/tcpdump.py.data/tcpdump.yaml "--execution-order tests-per-variant"
+avocado-misc-tests/io/net/irqbalance.py avocado-misc-tests/io/net/irqbalance.py.data/irqbalance_network.yaml
+avocado-misc-tests/io/common/virtual_bind_unbind.py avocado-misc-tests/io/common/virtual_bind_unbind.py.data/virtual_bind_unbind.yaml
+avocado-misc-tests/io/net/bonding.py avocado-misc-tests/io/net/bonding.py.data/bonding.yaml "--execution-order tests-per-variant"
+avocado-misc-tests/io/net/bridge.py avocado-misc-tests/io/net/bridge.py.data/bridge.yaml 
+avocado-misc-tests/io/net/virt-net/veth_dlpar.py avocado-misc-tests/io/net/virt-net/veth_dlpar.py.data/veth_dlpar.yaml
+avocado-misc-tests/io/driver/module_unload_load.py avocado-misc-tests/io/driver/module_unload_load.py.data/module_unload_load.yaml
+avocado-misc-tests/io/net/Network_config.py avocado-misc-tests/io/net/Network_config.py.data/Network_config.yaml
+avocado-misc-tests/io/net/multiport_stress.py avocado-misc-tests/io/net/multiport_stress.py.data/multiport_stress.yaml "--execution-order tests-per-variant"
+avocado-misc-tests/io/net/htx_nic_devices.py avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/driver/driver_parameter.py avocado-misc-tests/io/driver/driver_parameter.py.data/driver_parameter_ibmveth.yaml

--- a/config/tests/host/io_vnic_backing_htx_drmgr.cfg
+++ b/config/tests/host/io_vnic_backing_htx_drmgr.cfg
@@ -1,0 +1,8 @@
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_add avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_backingdevadd avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_start avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_vnic_dlpar avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_stop avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_backingdevremove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_remove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml

--- a/config/tests/host/io_vnic_backing_rmdev.cfg
+++ b/config/tests/host/io_vnic_backing_rmdev.cfg
@@ -1,0 +1,5 @@
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_add avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_backingdevadd avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_rmdev_viosfailover avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_backingdevremove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_remove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml

--- a/config/tests/host/io_vnic_bond_htx_dlpar.cfg
+++ b/config/tests/host/io_vnic_bond_htx_dlpar.cfg
@@ -1,0 +1,9 @@
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_add avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/bonding.py:Bonding.test_setup avocado-misc-tests/io/net/bonding.py.data/bonding_single.yaml
+avocado-misc-tests/io/net/bonding.py:Bonding.test_run avocado-misc-tests/io/net/bonding.py.data/bonding_single.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_start avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_vnic_dlpar avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_stop avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/bonding.py:Bonding.test_cleanup avocado-misc-tests/io/net/bonding.py.data/bonding_single.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_remove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml

--- a/config/tests/host/io_vnic_lpm_fvt.cfg
+++ b/config/tests/host/io_vnic_lpm_fvt.cfg
@@ -1,0 +1,7 @@
+avocado-misc-tests/io/net/network_test.py:NetworkTest.test_ping avocado-misc-tests/io/net/network_test.py.data/network_test_one_variant.yaml
+avocado-misc-tests/io/net/virt-net/lpm.py:LPM.test_migrate avocado-misc-tests/io/net/virt-net/lpm.py.data/lpm_withvnic.yaml
+avocado-misc-tests/io/net/network_test.py:NetworkTest.test_ping avocado-misc-tests/io/net/network_test.py.data/network_test_one_variant.yaml
+avocado-misc-tests/io/net/virt-net/lpm.py:LPM.test_migrate_back avocado-misc-tests/io/net/virt-net/lpm.py.data/lpm_withvnic.yaml
+avocado-misc-tests/io/net/network_test.py:NetworkTest.test_ping avocado-misc-tests/io/net/network_test.py.data/network_test_one_variant.yaml
+avocado-misc-tests/io/net/virt-net/lpm.py avocado-misc-tests/io/net/virt-net/lpm.py.data/lpm_5_iterations.yaml "--execution-order tests-per-variant"
+avocado-misc-tests/io/net/network_test.py:NetworkTest.test_ping avocado-misc-tests/io/net/network_test.py.data/network_test_one_variant.yaml

--- a/config/tests/host/io_vnic_perf.cfg
+++ b/config/tests/host/io_vnic_perf.cfg
@@ -1,0 +1,8 @@
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_add avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_backingdevadd avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/netperf_test.py avocado-misc-tests/io/net/netperf_test.py.data/netperf_test_virt.yaml "--execution-order tests-per-variant"
+avocado-misc-tests/io/net/uperf_test.py avocado-misc-tests/io/net/uperf_test.py.data/uperf_test_virt.yaml "--execution-order tests-per-variant" 
+avocado-misc-tests/io/net/multiport_stress.py avocado-misc-tests/io/net/multiport_stress.py.data/multiport_stress_virt.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_backingdevremove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_remove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml

--- a/config/tests/host/io_vnic_regression.cfg
+++ b/config/tests/host/io_vnic_regression.cfg
@@ -1,25 +1,17 @@
 avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_add avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
 avocado-misc-tests/io/net/bonding.py avocado-misc-tests/io/net/bonding.py.data/bonding_virtual.yaml "--execution-order tests-per-variant"
 avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_backingdevadd avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
-avocado-misc-tests/io/net/tcpdump.py avocado-misc-tests/io/net/tcpdump.py.data/tcpdump-virt.yaml "--execution-order tests-per-variant" 
+avocado-misc-tests/io/net/tcpdump.py avocado-misc-tests/io/net/tcpdump.py.data/tcpdump-virt.yaml "--execution-order tests-per-variant"
 avocado-misc-tests/io/common/bootlist_test.py avocado-misc-tests/io/common/bootlist_test.py.data/bootlist_test_network.yaml
 avocado-misc-tests/io/net/multicast.py avocado-misc-tests/io/net/multicast.py.data/multicast.yaml
-avocado-misc-tests/io/net/netperf_test.py avocado-misc-tests/io/net/netperf_test.py.data/netperf_test_virt.yaml "--execution-order tests-per-variant"
-avocado-misc-tests/io/net/uperf_test.py avocado-misc-tests/io/net/uperf_test.py.data/uperf_test_virt.yaml "--execution-order tests-per-variant" 
 avocado-misc-tests/io/net/ethtool_test.py avocado-misc-tests/io/net/ethtool_test.py.data/ethtool_test.yaml
 avocado-misc-tests/io/net/network_test.py avocado-misc-tests/io/net/network_test.py.data/network_test_virt_net.yaml "--execution-order tests-per-variant"
-avocado-misc-tests/cpu/numactl.py avocado-misc-tests/cpu/numactl.py.data/numa_network.yaml
-avocado-misc-tests/io/net/irqbalance.py avocado-misc-tests/io/net/irqbalance.py.data/irqbalance_network.yaml
 avocado-misc-tests/io/net/bridge.py avocado-misc-tests/io/net/bridge.py.data/bridge.yaml
-avocado-misc-tests/io/net/multiport_stress.py avocado-misc-tests/io/net/multiport_stress.py.data/multiport_stress_virt.yaml
-avocado-misc-tests/io/net/Network_config.py avocado-misc-tests/io/net/Network_config.py.data/Network_config.yaml
-avocado-misc-tests/io/net/htx_nic_devices.py avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
 avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_hmcfailover avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
 avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_clientfailover avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
 avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_vnic_auto_failover avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
 avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_rmdev_viosfailover avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
 avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_vnic_dlpar avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
-avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_disable_enable_dev avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
 avocado-misc-tests/io/driver/module_unload_load.py avocado-misc-tests/io/driver/module_unload_load.py.data/module_unload_load.yaml
 avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_backingdevremove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
 avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_remove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml

--- a/config/tests/host/io_vnic_scenario_backing_htx_failover.cfg
+++ b/config/tests/host/io_vnic_scenario_backing_htx_failover.cfg
@@ -1,0 +1,8 @@
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_add avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_backingdevadd avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_start avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_vnic_auto_failover avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_stop avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_backingdevremove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_remove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml

--- a/config/tests/host/io_vnic_scenario_bond_htx.cfg
+++ b/config/tests/host/io_vnic_scenario_bond_htx.cfg
@@ -1,0 +1,8 @@
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_add avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/multiple_vnic_nobacking.yaml
+avocado-misc-tests/io/net/bonding.py:Bonding.test_setup avocado-misc-tests/io/net/bonding.py.data/bonding_single.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_start avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/bonding.py:Bonding.test_run avocado-misc-tests/io/net/bonding.py.data/bonding_single.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_stop avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+avocado-misc-tests/io/net/bonding.py:Bonding.test_cleanup avocado-misc-tests/io/net/bonding.py.data/bonding_single.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_remove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/multiple_vnic_nobacking.yaml

--- a/config/tests/host/io_vnic_scenario_goodpath.cfg
+++ b/config/tests/host/io_vnic_scenario_goodpath.cfg
@@ -9,7 +9,7 @@ avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-
 avocado-misc-tests/cpu/cpustress.py avocado-misc-tests/cpu/cpustress.py.data/cpustress.yaml
 avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
 
-avocado-misc-tests/memory/memtester.py
+avocado-misc-tests/memory/memtester.py avocado-misc-tests/memory/memtester.py.data/memtester.yaml
 avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
 
 avocado-misc-tests/io/net/bonding.py:Bonding.test_setup avocado-misc-tests/io/net/bonding.py.data/bonding_single.yaml
@@ -32,4 +32,3 @@ avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-
 
 avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_stop avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
 avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_remove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
-

--- a/config/tests/host/io_vnic_scenario_mtu9000_bond_failover.cfg
+++ b/config/tests/host/io_vnic_scenario_mtu9000_bond_failover.cfg
@@ -1,0 +1,5 @@
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_add avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/multiple_vnic_nobacking.yaml
+avocado-misc-tests/io/net/bonding.py:Bonding.test_setup avocado-misc-tests/io/net/bonding.py.data/bonding_single.yaml
+avocado-misc-tests/io/net/bonding.py:Bonding.test_run avocado-misc-tests/io/net/bonding.py.data/bonding_single.yaml
+avocado-misc-tests/io/net/bonding.py:Bonding.test_cleanup avocado-misc-tests/io/net/bonding.py.data/bonding_single.yaml
+avocado-misc-tests/io/net/virt-net/network_virtualization.py:NetworkVirtualization.test_remove avocado-misc-tests/io/net/virt-net/network_virtualization.py.data/multiple_vnic_nobacking.yaml


### PR DESCRIPTION
This patch has updated test bucket of vNIC and vETH that aligned with update of "avocado-fvt-wrapper" test bucket.