### PR TITLE
Added nfs-utils dependency as a requirement

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -13,17 +13,17 @@ optional = [('avocado-framework-plugin-result-html', '')]
 name = [('https://github.com/avocado-framework-tests/avocado-misc-tests.git', '')]
 
 [deps_centos]
-packages = gcc,python3-devel,python3-setuptools,numactl,python3-policycoreutils
+packages = gcc,python3-devel,python3-setuptools,numactl,python3-policycoreutils,nfs-utils
 [deps_centos9]
-packages = gcc,python3-devel,python3-setuptools,numactl,python3-policycoreutils
+packages = gcc,python3-devel,python3-setuptools,numactl,python3-policycoreutils,nfs-utils
 [deps_centos_NV]
 packages =
 [deps_centos_pHyp]
 packages =
 [deps_centos_kvm]
-packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,attr
+packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,attr,nfs-utils
 [deps_centos9_kvm]
-packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,xorriso,attr
+packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,xorriso,attr,nfs-utils
 [deps_ubuntu]
 packages = gcc,python3-dev,python3-setuptools,numactl
 [deps_ubuntu_NV]


### PR DESCRIPTION
Signed-off-by: Kowshik Jois B S kowsjois@linux.ibm.com

Description: There are lot of tests which are dependent on exportfs command which is provided by nfs-utils package. Hence adding it as a required dependancy.