### PR TITLE
Adding nfs-utils package for RHEL!

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -65,7 +65,7 @@ packages = enchant
 [deps_rhel8_kvm]
 packages = libvirt-devel,tcpdump,virt-install,qemu-kvm,libvirt,SLOF,genisoimage,attr
 [deps_rhel9]
-packages = gcc,python3-devel,xz-devel,python3-setuptools,numactl,policycoreutils-python-utils,openssl-devel
+packages = gcc,python3-devel,xz-devel,python3-setuptools,numactl,policycoreutils-python-utils,openssl-devel,nfs-utils
 [deps_rhelbe]
 packages = gcc,python3-devel,xz-devel,python3-setuptools,numactl
 [deps_rhelbe_NV]


### PR DESCRIPTION
nfs-utils package is required for exportfs command needed by few testcases. Adding "nfs-utils" packag e installation for rhel9 system.
Signed-off-by: Anushree Mathur <anushree.mathur@linux.vnet.ibm.com>