### PR TITLE
removed unsupported kqemu tests from config

### DIFF
--- a/config/tests/guest/libvirt/cpu.cfg
+++ b/config/tests/guest/libvirt/cpu.cfg
@@ -56,6 +56,10 @@ variants:
                 no virsh.vcpupin.online.positive_test.initial_check  # Bug https://bugzilla.linux.ibm.com/show_bug.cgi?id=147326 - Will not fix
             - maxvcpus:
                 only virsh.maxvcpus
+                no virsh.maxvcpus.connect_to_local.with_option.with_kqemu
+                no virsh.maxvcpus.connect_to_local.with_option.with_kqemu1
+                no virsh.maxvcpus.connect_to_remote.with_option.with_kqemu
+                no virsh.maxvcpus.connect_to_remote.with_option.with_kqemu1
             - nodecpumap:
                 only virsh.nodecpumap
             - schedinfo:

--- a/config/tests/guest/libvirt/regression.cfg
+++ b/config/tests/guest/libvirt/regression.cfg
@@ -67,6 +67,10 @@ variants:
                         no virsh.vcpupin.online.positive_test.initial_check
                     - maxvcpus:
                         only virsh.maxvcpus
+                        no virsh.maxvcpus.connect_to_local.with_option.with_kqemu
+                        no virsh.maxvcpus.connect_to_local.with_option.with_kqemu1
+                        no virsh.maxvcpus.connect_to_remote.with_option.with_kqemu
+                        no virsh.maxvcpus.connect_to_remote.with_option.with_kqemu1
                     - nodecpumap:
                         only virsh.nodecpumap
                     - schedinfo:


### PR DESCRIPTION
Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>

Description: kqemu x86 specific is no more supported.

Source: https://wiki.qemu.org/Documentation/KQemu