### PR TITLE
Remove duplicate tests from regression config

### DIFF
--- a/config/tests/guest/libvirt/regression.cfg
+++ b/config/tests/guest/libvirt/regression.cfg
@@ -132,7 +132,6 @@ variants:
                         only virsh.net_create
                     - net_virsh_net_destroy:
                         only virsh.net_destroy
-                        no virsh.net_destroy.normal_test.non_acl.default_option
                     - net_virsh_net_dhcp_leases:
                         only virsh.net_dhcp_leases
                     - net_virsh_net_dumpxml:
@@ -208,38 +207,12 @@ variants:
                         only virsh.domiflist.with_valid_option.domid,virsh.domiflist.with_invalid_option.none
                     - domif-setgetlink:
                         only virsh.domif_setlink_getlink.positive_test.interface_net.no_config.running_guest.domif_setlink.setlink_up,virsh.domif_setlink_getlink.negative_test.running_guest_invalid_option
-                    - domifstat:
-                        only virsh.domifstat.normal_test.id_option,virsh.domifstat.error_test.no_option
                     - domiftune:
                         only virsh.domiftune.positive_testing.get_domif_parameter.running_guest.options.none,virsh.domiftune.negative_testing.get_domif_parameter.running_guest.options.none
-                    - net-autostart:
-                        only virsh.net_autostart.normal_test.set_autostart.netname,virsh.net_autostart.error_test.none_network
-                    - net-create:
-                        only virsh.net_create.normal_test.file_as_argument.default_config,virsh.net_create.error_test.bad_command_line.additional_file.no_extra_options.no_existing_removal
-                    - net-destroy:
-                        only virsh.net_destroy.normal_test.non_acl.default_option,virsh.net_destroy.error_test.no_option
-                    - net-dumpxml:
-                        only virsh.net_dumpxml.normal_test.non_acl.name_option,virsh.net_dumpxml.error_test.space_option
-                    - net-info:
-                        only virsh.net_info.normal_test.name_option,virsh.net_info.error_test.additional_option
-                    - net-list:
-                        only virsh.net_list.normal_test.non_acl.no_option,virsh.net_list.error_test.extra_option
-                    - net-name:
-                        only virsh.net_name.uuid_option,virsh.net_name.error_test.name_option
                     - net-start:
                         only virsh.net_start.normal_test.non_acl.valid_netname,virsh.net_start.error_test.none
-                    - net-uuid:
-                        only virsh.net_uuid.name_option,virsh.net_uuid.error_test.no_option
-                    - nwfilter-define:
-                        only virsh.nwfilter_define.update_exist_filter.non_acl.same_uuid,virsh.nwfilter_define.negative_test.no_xml_file
-                    - nwfilter-dumpxml:
-                        only virsh.nwfilter_dumpxml.normal_test.non_acl,virsh.nwfilter_dumpxml.error_test.none_option
                     - nwfilter-edit:
                         only virsh.nwfilter_edit.positive_test.use_name,virsh.nwfilter_edit.negative_test.invalid_name
-                    - nwfilter-list:
-                        only virsh.nwfilter_list.normal_test.non_acl,virsh.nwfilter_list.error_test
-                    - nwfilter-undefine:
-                        only virsh.nwfilter_undefine.normal_test.non_acl,virsh.nwfilter_undefine.error_test.none_option
                     - delete_guest:
                         only remove_guest.without_disk
 
@@ -551,8 +524,6 @@ variants:
                 variants:
                     - import:
                         only unattended_install.import.import.default_install.aio_native
-                    - save:
-                        only virsh.save.normal_test.id_option.no_option.no_progress,virsh.save.error_test.no_option
                     - snapshot-disk:
                         only virsh.snapshot_disk
                         no virsh.snapshot_disk.no_delete..attach_img_qed


### PR DESCRIPTION
Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>

There are 25 tests which were redundant in regression.cfg file.

For example, all the tests under "virsh.domifstat" are running as part of "net_virsh_domifstat" group. But 2 of them would run again under "domifstat" group.

This PR will remove all such duplicate tests from the regression config