### PR TITLE
Removing testcases from regression testbucket!

### DIFF
--- a/config/tests/guest/libvirt/regression.cfg
+++ b/config/tests/guest/libvirt/regression.cfg
@@ -322,6 +322,8 @@ variants:
                         no virsh.vol_download_upload.download_upload.netfs_pool..0-end
                         no virsh.vol_download_upload.download_upload.netfs_pool..1024-end
                         no virsh.vol_download_upload.download_upload.netfs_pool..no_options
+                        no virsh.vol_download_upload.mix_download_upload.dir_pool.sparse
+                        no virsh.vol_download_upload.only_download.iscsi_pool
                     - vol_clone_wipe:
                         only virsh.vol_clone_wipe
                         no virsh.vol_clone_wipe.positive_test.non_acl.disk_part.pool_type.disk#test case needs fix no storage vol '/dev/sdn1 found


### PR DESCRIPTION
Removing two testcases from regression config's storage component as those are not part of storage config too.
Signed-off-by: Anushree Mathur <anushree.mathur@linux.vnet.ibm.com>