### PR TITLE
Removing testcases from regression testbucket!

### DIFF
--- a/config/tests/guest/libvirt/regression.cfg
+++ b/config/tests/guest/libvirt/regression.cfg
@@ -236,6 +236,7 @@ variants:
                         no virsh.pool.positive_test.pool_type_disk.source_format_bsd
                         no virsh.pool.positive_test.pool_type_disk.source_format_pc98
                         no virsh.pool.positive_test.pool_type_disk.source_format_sun
+                        no virsh.pool.positive_test.pool_type_iscsi_direct
                     - pool_create:
                         only virsh.pool_create
                         no virsh.pool_create.positive_test.from_given_file # SKIP this requires a pool.xml to be passed manually to PASS
@@ -304,6 +305,8 @@ variants:
                         only virsh.vol_resize
                         no virsh.vol_resize.positive_test..allocate_capacity.netfs
                         no virsh.vol_resize.positive_test..delta_allocate_capacity.netfs
+                        no virsh.vol_resize.positive_test.luks_encrypt.non_acl.allocate_capacity
+                        no virsh.vol_resize.positive_test.luks_encrypt.non_acl.delta_allocate_capacity
                     - vol_download_upload:
                         only virsh.vol_download_upload
                         no virsh.vol_download_upload.download_upload.disk_pool..0-1024


### PR DESCRIPTION
Removing two testcases from regression config's storage component as those are not part of storage config too.
Signed-off-by: Anushree Mathur <anushree.mathur@linux.vnet.ibm.com>