### PR TITLE
Removed unsupported tests from regression config

### DIFF
--- a/config/tests/guest/libvirt/regression.cfg
+++ b/config/tests/guest/libvirt/regression.cfg
@@ -156,6 +156,7 @@ variants:
                         only virsh.nwfilter_undefine
                     - net_virtual_network_iface_hotplug:
                         only virtual_network.iface_hotplug
+                        only model_virtio #The other models 'e1000, rtl8139 and e1000e' are unsupported
                     - net_virtual_network_iface_network:
                         only virtual_network.iface_network
                         no virtual_network.iface_network.dnsmasq_test.net_host_ip


### PR DESCRIPTION
Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>

Description: The models 'e1000, rtl8139 and e1000e' are unsupported and are not running as part of network test bucket. Hence removing them from regression config too!