### PR TITLE
NIC: inputfile create fails due to hard link issue

### DIFF
--- a/lib/pci.py
+++ b/lib/pci.py
@@ -188,8 +188,7 @@ def get_interfaces_in_pci_address(pci_address, pci_class):
     if not pci_class or not os.path.isdir(pci_class_path):
         return ""
     return [interface for interface in os.listdir(pci_class_path)
-            if pci_address in os.readlink(os.path.join(pci_class_path,
-                                                       interface))]
+            if os.path.islink(os.path.join(pci_class_path, interface)) and pci_address in os.readlink(os.path.join(pci_class_path, interface))]
 
 
 def get_pci_class_name(pci_address):


### PR DESCRIPTION
while creating inputfile for network devices the script fails at get_interfaces_in_pci_address() to fetch pci interface name with below error

  File "/root/tests/lib/pci.py", line 331, in <listcomp>
    if pci_address in os.readlink(os.path.join(pci_class_path,
OSError: [Errno 22] Invalid argument: '/sys/class/net/bonding_masters'

This patch make sures the hardlinks are ignored and only the symlinks are checked for pci address