### PR TITLE
Updated io_fc_fvt.cfg file

### DIFF
--- a/config/tests/host/io_fc_fvt.cfg
+++ b/config/tests/host/io_fc_fvt.cfg
@@ -2,6 +2,7 @@ avocado-misc-tests/ras/ras_lsvpd.py:RASToolsLsvpd.test_pci_lsvpd
 avocado-misc-tests/io/common/bootlist_test.py avocado-misc-tests/io/common/bootlist_test.py.data/bootlist_test_disk.yaml
 avocado-misc-tests/io/common/distro_tools.py avocado-misc-tests/io/common/distro_tools.py.data/distro_tools_common.yaml
 avocado-misc-tests/io/common/distro_tools.py avocado-misc-tests/io/common/distro_tools.py.data/distro_tools_pci.yaml
+avocado-misc-tests/io/disk/sysfsdisk_att.py avocado-misc-tests/io/disk/sysfsdisk_att.py.data/sysfsdisk_att.yaml
 avocado-misc-tests/io/disk/bonnie.py avocado-misc-tests/io/disk/bonnie.py.data/bonnie.yaml
 avocado-misc-tests/io/disk/rawread.py avocado-misc-tests/io/disk/rawread.py.data/rawread.yaml
 avocado-misc-tests/io/disk/tiobench.py avocado-misc-tests/io/disk/tiobench.py.data/tiobench.yaml
@@ -44,10 +45,11 @@ avocado-misc-tests/cpu/ppc64_cpu_test.py:PPC64Test.test_smt_loop
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
 avocado-misc-tests/cpu/cpustress.py avocado-misc-tests/cpu/cpustress.py.data/cpustress.yaml
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
-avocado-misc-tests/io/pci/EEH.py avocado-misc-tests/io/pci/EEH.py.data/EEH.yaml
-avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
+avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_stop avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
 avocado-misc-tests/io/driver/module_unload_load.py avocado-misc-tests/io/driver/module_unload_load.py.data/module_unload_load.yaml
 avocado-misc-tests/io/driver/driver_parameter_block_device.py avocado-misc-tests/io/driver/driver_parameter_block_device.py.data/driver_parameter_block_device_lpfc.yaml
 avocado-misc-tests/io/driver/driver_parameter_block_device.py avocado-misc-tests/io/driver/driver_parameter_block_device.py.data/driver_parameter_block_device_qla2xxx.yaml
+avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_start avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
+avocado-misc-tests/io/pci/EEH.py avocado-misc-tests/io/pci/EEH.py.data/EEH.yaml
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_stop avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml


### PR DESCRIPTION
Module load/unload and Driver parameter block device Above mentioned test can't be peformed with io
To avoid this, above mentioned tests are moved before Htx start testcase Can't perform tests after EEH as system needs reboot after max EEH So EEH test case is kept as last tescase