### PR TITLE
Removing testcases for rename-restart

### DIFF
--- a/config/tests/guest/libvirt/lifecycle.cfg
+++ b/config/tests/guest/libvirt/lifecycle.cfg
@@ -118,6 +118,9 @@ variants:
                 only virsh.domname
             - domstate:
                 only virsh.domstate
+                # Only supported for libxl hypervisor driver
+                no virsh.domstate.normal_test.reason.crash_vm.oncrash_rename_restart.restart_libvirtd
+                no virsh.domstate.normal_test.reason.crash_vm.oncrash_rename_restart.normal 
             - domuuid:
                 only virsh.domuuid
             - domxml:


### PR DESCRIPTION
rename-restart option for on_crash is supported only by libxl hypervisor driver. As per (https://libvirt.org/formatdomain.html
Signed-off-by: Anushree Mathur <anushree.mathur@linux.vnet.ibm.com>