### PR TITLE
Fix SyntaxWarning and future SyntaxError: \S

### DIFF
--- a/lib/helper.py
+++ b/lib/helper.py
@@ -72,13 +72,13 @@ def get_dist():
             if line.startswith("ID="):
                 try:
                     line = line.replace('"', '')
-                    dist = re.findall("ID=(\S+)", line)[0]
+                    dist = re.findall("ID=(\\S+)", line)[0]
                 except:
                     pass
             elif line.startswith("VERSION="):
                 try:
                     line = line.replace('"', '')
-                    dist_ver = re.findall("VERSION=(\S+)", line)[0].lower().replace("-", ".")
+                    dist_ver = re.findall("VERSION=(\\S+)", line)[0].lower().replace("-", ".")
                 except:
                     pass
         fd.close()


### PR DESCRIPTION
### Fix SyntaxWarning and future SyntaxError: \S

Using \S produces _**SyntaxWarning**_ in Python3.12
Continued usage of \S in higher Python versions
will result in _**SyntaxError**_
Using \\\S solves the issue

Signed-off-by: Misbah Anjum N <misanjum@linux.vnet.ibm.com>