### PR TITLE
Update ras.cfg to test more virsh dump options

### DIFF
--- a/config/tests/guest/libvirt/ras.cfg
+++ b/config/tests/guest/libvirt/ras.cfg
@@ -41,27 +41,16 @@ mem = 32768
 variants:
     - guest_import:
         only unattended_install.import.import.default_install.aio_native
+
     - guest_ras:
         dump_dir = '/home'
         variants:
             - non_acl:
                 only virsh.dump.positive_test.non_acl
-                no virsh.dump.positive_test.non_acl.bypass_cache_dump
-                no virsh.dump.positive_test.non_acl.bypass_cache_reset_dump
-                no virsh.dump.positive_test.non_acl.memory_dump.kdump-lzo_format # N/A
-                no virsh.dump.positive_test.non_acl.memory_dump.kdump-snappy_format # N/A
-                no virsh.dump.positive_test.non_acl.memory_bypass_cache_dump # ERROR: /tmp/aexpect_WowQLV5g/lock-server-running
-                no virsh.dump.positive_test.non_acl.lzop_format_dump
 
             - acl_test:
                 action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                 only virsh.dump.positive_test.acl_test
-                no virsh.dump.positive_test.acl_test.bypass_cache_dump
-                no virsh.dump.positive_test.acl_test.bypass_cache_reset_dump
-                no virsh.dump.positive_test.acl_test.memory_dump.kdump-lzo_format # N/A
-                no virsh.dump.positive_test.acl_test.memory_dump.kdump-snappy_format # N/A
-                no virsh.dump.positive_test.acl_test.memory_bypass_cache_dump # ERROR: /tmp/aexpect_WowQLV5g/lock-server-running
-                no virsh.dump.positive_test.acl_test.lzop_format_dump
 
             - negative:
                 only virsh.dump.negative_test


### PR DESCRIPTION
### Update ras.cfg to test more virsh dump options

Enable testing of more virsh dump options through ras.cfg
Earlier these test-cases were not supported and returned Error
But now they can be enabled for testing ras capabilities in Guests/VMs
The test will return Cancel state if the dump format is not supported by QEMU

The following virsh dump tests can be enabled using this patch:
- bypass-cache
- kdump-lzo memory dump format
- kdump-snappy memory dump format
- lzop format

Signed-off-by: Misbah Anjum N <misanjum@linux.vnet.ibm.com>