### PR TITLE
Update avocado-vt lifecycle.cfg to remove a test-case

### DIFF
--- a/config/tests/guest/libvirt/lifecycle.cfg
+++ b/config/tests/guest/libvirt/lifecycle.cfg
@@ -121,6 +121,8 @@ variants:
                 # Only supported for libxl hypervisor driver
                 no virsh.domstate.normal_test.reason.crash_vm.oncrash_rename_restart.restart_libvirtd
                 no virsh.domstate.normal_test.reason.crash_vm.oncrash_rename_restart.normal 
+                # Stops libvirt and kills VM, thus halting the test run
+                no virsh.domstate.error_test.kill_vm.after_stopping_libvirtd
             - domuuid:
                 only virsh.domuuid
             - domxml:


### PR DESCRIPTION
## Update avocado-vt lifecycle.cfg to remove a test-case

Removed Testcase:
virsh.domstate.error_test.kill_vm.after_stopping_libvirtd

- The testcase stops libvirt and kills vm. After that, the entire bucket stops running.
- One has to manually add this line in .cfg file every single time to run the lifecycle bucket without any halting.

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)