### PR TITLE
Generate .html analysis file for avocado runs and update usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ So, if such tests are identified and need to be "not run" for a particular envir
 -----
 
 ### Analysis of results:
-analysis.py script is used to simplify analysis/comparison of avocado test runs by generating an excel file (.xlsx) of the same. The results.json file which gets created after avocado run, is passed as input in command line. Depending on the flag/options provided, the excel sheet will be generated.
+analysis.py script is used to simplify analysis/comparison of avocado test runs by generating excel and html files (.xlsx and .html) of the same. The results.json file which gets created after avocado run, is passed as input in command line. Depending on the flag/options provided, the excel sheet will be generated.
 
 > `$ python3 analysis.py [--options] [input(s)]`
 
@@ -316,7 +316,9 @@ analysis.py script is used to simplify analysis/comparison of avocado test runs 
     > `$ python3 analysis.py --new-analysis [json_file]`
 
 2. `--add-to-existing`:
-    > This flag is used to append new results.json dat to an already existing excel file. This flag can be used to compare new runs with the previous runs so that we can have our own analysis.
+    > Work in Progress (Future Enhancement)
+
+    > This flag is used to append new results.json data to an already existing excel file. This flag can be used to compare mutliple new runs with the previous runs so that we can have our own analysis.
 
     > `$ python3 analysis.py --add-to-existing [xlsx_file] [json_file]`
 


### PR DESCRIPTION
### Generate .html analysis file for avocado runs and update usage

1. Generation of .html output

- In addition to Analysis.xlsx, this patch generates Analysis.html file as output. This can be generated for new analysis (--new-analysis) as well as comparison analysis (--compare-two-results)
- The Analysis.xlsx file is converted to Analysis.html file and both the outputs are generated. This .html file can be used to display the summary of the avocado based results in a web page for a dashboard based view.
- This .html output has filter table drop downs as an enhancement to the .xlsx output. This filter can be used for further breaking down of the results.
- The summary data-structure is added to pass it as input to analysis_to_html(summary) function for displaying the number of regressions, differences and solved test-cases


2. Remove --add-to-existing flag

- There are many issues with this flag when it comes to both Analysis.xlsx as well as Analysis.html files generation. Much work is needed. 
- Hence, updating the readme marking it as future enhancement and removing it from the .py file.

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)