### PR TITLE
Update ras.cfg to remove dump_dir parameter

### DIFF
--- a/config/tests/guest/libvirt/ras.cfg
+++ b/config/tests/guest/libvirt/ras.cfg
@@ -43,7 +43,6 @@ variants:
         only unattended_install.import.import.default_install.aio_native
 
     - guest_ras:
-        dump_dir = '/home'
         variants:
             - non_acl:
                 only virsh.dump.positive_test.non_acl


### PR DESCRIPTION
### Update ras.cfg to remove dump_dir parameter

- The dump_dir parameter in ras.cfg overwrites the dump_dir parameter in the virsh_dump.cfg
- This causes the the dump_dir parameter in virsh_dump.cfg to become redundant
- Furthermore, one of the negative testcases fails since the default dump directory /var/tmp is required for the scenario 
- Hence removing the paramter from the ras.cfg in order to use the default /var/tmp directory for capturing guest vmcore

With the patch:
dump_dir = "/var/tmp" (default)

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)
