### PR TITLE
Fix for commented VERSION key in /etc/os-release file

### DIFF
--- a/lib/helper.py
+++ b/lib/helper.py
@@ -76,7 +76,7 @@ def get_dist():
                     dist = re.findall("ID=(\\S+)", line)[0]
                 except:
                     pass
-            elif line.startswith("VERSION="):
+            elif line.__contains__("VERSION="):
                 try:
                     line = line.replace('"', '')
                     dist_ver = re.findall("VERSION=(\\S+)", line)[0].lower().replace("-", ".")


### PR DESCRIPTION
Description: In some distros(like OpenSUSE), /etc/os-release file has commented "VERSION" key. In this scenario, bootstrap will fail. So adding a fix to get the value of version even if it is commented.

Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>