### PR TITLE
Adopt cpustress test name changes into all cfg

### DIFF
--- a/config/tests/host/io_fc_fvt.cfg
+++ b/config/tests/host/io_fc_fvt.cfg
@@ -42,7 +42,7 @@ avocado-misc-tests/cpu/xive.py
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
 avocado-misc-tests/cpu/ppc64_cpu_test.py:PPC64Test.test_smt_loop
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
-avocado-misc-tests/cpu/cpustress.py avocado-misc-tests/cpu/cpustress.py.data/cpustress.yaml
+avocado-misc-tests/cpu/cpuhotplug.py avocado-misc-tests/cpu/cpuhotplug.py.data/cpuhotplug.yaml
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
 avocado-misc-tests/io/pci/EEH.py avocado-misc-tests/io/pci/EEH.py.data/EEH.yaml
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml

--- a/config/tests/host/io_infiniband_fvt.cfg
+++ b/config/tests/host/io_infiniband_fvt.cfg
@@ -32,7 +32,7 @@ avocado-misc-tests/io/driver/driver_parameter.py avocado-misc-tests/io/driver/dr
 avocado-misc-tests/io/driver/driver_parameter.py avocado-misc-tests/io/driver/driver_parameter.py.data/driver_parameter_mlx5_ib.yaml
 avocado-misc-tests/io/net/tcpdump.py avocado-misc-tests/io/net/tcpdump.py.data/tcpdump.yaml
 avocado-misc-tests/io/net/bonding.py avocado-misc-tests/io/net/bonding.py.data/bonding_infiniband.yaml "--execution-order tests-per-variant"
-avocado-misc-tests/cpu/cpustress.py avocado-misc-tests/cpu/cpustress.py.data/cpustress.yaml
+avocado-misc-tests/cpu/cpuhotplug.py avocado-misc-tests/cpu/cpuhotplug.py.data/cpuhotplug.yaml
 avocado-misc-tests/memory/memtester.py avocado-misc-tests/memory/memtester.py.data/memtester.yaml
 avocado-misc-tests/io/pci/EEH.py avocado-misc-tests/io/pci/EEH.py.data/EEH.yaml
 avocado-misc-tests/io/pci/dlpar.py avocado-misc-tests/io/pci/dlpar.py.data/dlpar.yaml

--- a/config/tests/host/io_network_scenario_goodpath.cfg
+++ b/config/tests/host/io_network_scenario_goodpath.cfg
@@ -5,7 +5,7 @@ avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-
 avocado-misc-tests/cpu/ppc64_cpu_test.py:PPC64Test.test_smt_loop
 avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
 
-avocado-misc-tests/cpu/cpustress.py avocado-misc-tests/cpu/cpustress.py.data/cpustress.yaml
+avocado-misc-tests/cpu/cpuhotplug.py avocado-misc-tests/cpu/cpuhotplug.py.data/cpuhotplug.yaml
 avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
 
 avocado-misc-tests/memory/memtester.py

--- a/config/tests/host/io_network_scenario_goodpath_fvt.cfg
+++ b/config/tests/host/io_network_scenario_goodpath_fvt.cfg
@@ -5,7 +5,7 @@ avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-
 avocado-misc-tests/cpu/ppc64_cpu_test.py:PPC64Test.test_smt_loop
 avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
 
-avocado-misc-tests/cpu/cpustress.py avocado-misc-tests/cpu/cpustress.py.data/cpustress.yaml
+avocado-misc-tests/cpu/cpuhotplug.py avocado-misc-tests/cpu/cpuhotplug.py.data/cpuhotplug.yaml
 avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
 
 avocado-misc-tests/memory/memtester.py

--- a/config/tests/host/io_nvmf_fvt.cfg
+++ b/config/tests/host/io_nvmf_fvt.cfg
@@ -42,7 +42,7 @@ avocado-misc-tests/cpu/xive.py
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
 avocado-misc-tests/cpu/ppc64_cpu_test.py:PPC64Test.test_smt_loop
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
-avocado-misc-tests/cpu/cpustress.py avocado-misc-tests/cpu/cpustress.py.data/cpustress.yaml
+avocado-misc-tests/cpu/cpuhotplug.py avocado-misc-tests/cpu/cpuhotplug.py.data/cpuhotplug.yaml
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
 avocado-misc-tests/io/pci/EEH.py avocado-misc-tests/io/pci/EEH.py.data/EEH.yaml
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml

--- a/config/tests/host/io_nvmf_rhel8_fvt.cfg
+++ b/config/tests/host/io_nvmf_rhel8_fvt.cfg
@@ -42,7 +42,7 @@ avocado-misc-tests/cpu/xive.py
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
 avocado-misc-tests/cpu/ppc64_cpu_test.py:PPC64Test.test_smt_loop
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
-avocado-misc-tests/cpu/cpustress.py avocado-misc-tests/cpu/cpustress.py.data/cpustress.yaml
+avocado-misc-tests/cpu/cpuhotplug.py avocado-misc-tests/cpu/cpuhotplug.py.data/cpuhotplug.yaml
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
 avocado-misc-tests/io/pci/EEH.py avocado-misc-tests/io/pci/EEH.py.data/EEH.yaml
 avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml

--- a/config/tests/host/io_roce_fvt.cfg
+++ b/config/tests/host/io_roce_fvt.cfg
@@ -42,7 +42,7 @@ avocado-misc-tests/io/net/infiniband/dapl.py avocado-misc-tests/io/net/infiniban
 avocado-misc-tests/io/net/bonding.py avocado-misc-tests/io/net/bonding.py.data/bonding.yaml "--execution-order tests-per-variant"
 avocado-misc-tests/io/net/ethtool_test.py avocado-misc-tests/io/net/ethtool_test.py.data/ethtool_test.yaml
 avocado-misc-tests/io/net/htx_nic_devices.py avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
-avocado-misc-tests/cpu/cpustress.py avocado-misc-tests/cpu/cpustress.py.data/cpustress.yaml
+avocado-misc-tests/cpu/cpuhotplug.py avocado-misc-tests/cpu/cpuhotplug.py.data/cpuhotplug.yaml
 avocado-misc-tests/memory/memtester.py avocado-misc-tests/memory/memtester.py.data/memtester.yaml
 avocado-misc-tests/io/net/vlan_test.py avocado-misc-tests/io/net/vlan_test.py.data/vlan.yaml
 avocado-misc-tests/io/pci/EEH.py avocado-misc-tests/io/pci/EEH.py.data/EEH.yaml

--- a/config/tests/host/io_roce_mlx4_fvt.cfg
+++ b/config/tests/host/io_roce_mlx4_fvt.cfg
@@ -43,7 +43,7 @@ avocado-misc-tests/io/driver/driver_parameter.py avocado-misc-tests/io/driver/dr
 avocado-misc-tests/io/driver/driver_parameter.py avocado-misc-tests/io/driver/driver_parameter.py.data/driver_parameter_mlx4_ib.yaml
 avocado-misc-tests/io/net/htx_nic_devices.py avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
 avocado-misc-tests/io/net/vlan_test.py avocado-misc-tests/io/net/vlan_test.py.data/vlan.yaml
-avocado-misc-tests/cpu/cpustress.py avocado-misc-tests/cpu/cpustress.py.data/cpustress.yaml
+avocado-misc-tests/cpu/cpuhotplug.py avocado-misc-tests/cpu/cpuhotplug.py.data/cpuhotplug.yaml
 avocado-misc-tests/memory/memtester.py avocado-misc-tests/memory/memtester.py.data/memtester.yaml
 avocado-misc-tests/io/net/bonding.py avocado-misc-tests/io/net/bonding.py.data/bonding.yaml "--execution-order tests-per-variant"
 avocado-misc-tests/io/pci/EEH.py avocado-misc-tests/io/pci/EEH.py.data/EEH.yaml

--- a/config/tests/host/io_usb_fvt.cfg
+++ b/config/tests/host/io_usb_fvt.cfg
@@ -22,6 +22,6 @@ avocado-misc-tests/io/pci/pci_hotplug.py avocado-misc-tests/io/pci/pci_hotplug.p
 avocado-misc-tests/io/pci/dlpar.py avocado-misc-tests/io/pci/dlpar.py.data/dlpar.yaml
 avocado-misc-tests/cpu/xive.py
 avocado-misc-tests/cpu/ppc64_cpu_test.py:PPC64Test.test_smt_loop
-avocado-misc-tests/cpu/cpustress.py avocado-misc-tests/cpu/cpustress.py.data/cpustress.yaml
+avocado-misc-tests/cpu/cpuhotplug.py avocado-misc-tests/cpu/cpuhotplug.py.data/cpuhotplug.yaml
 avocado-misc-tests/io/driver/module_unload_load.py avocado-misc-tests/io/driver/module_unload_load.py.data/module_unload_load.yaml
 avocado-misc-tests/io/driver/driver_parameter_block_device.py avocado-misc-tests/io/driver/driver_parameter_block_device.py.data/driver_parameter_block_device_xhci_hcd.yaml

--- a/config/tests/host/io_vnic_scenario_goodpath.cfg
+++ b/config/tests/host/io_vnic_scenario_goodpath.cfg
@@ -6,7 +6,7 @@ avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-
 avocado-misc-tests/cpu/ppc64_cpu_test.py:PPC64Test.test_smt_loop
 avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
 
-avocado-misc-tests/cpu/cpustress.py avocado-misc-tests/cpu/cpustress.py.data/cpustress.yaml
+avocado-misc-tests/cpu/cpuhotplug.py avocado-misc-tests/cpu/cpuhotplug.py.data/cpuhotplug.yaml
 avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
 
 avocado-misc-tests/memory/memtester.py

--- a/config/tests/host/io_vnic_scenario_goodpath_fvt.cfg
+++ b/config/tests/host/io_vnic_scenario_goodpath_fvt.cfg
@@ -6,7 +6,7 @@ avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-
 avocado-misc-tests/cpu/ppc64_cpu_test.py:PPC64Test.test_smt_loop
 avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
 
-avocado-misc-tests/cpu/cpustress.py avocado-misc-tests/cpu/cpustress.py.data/cpustress.yaml
+avocado-misc-tests/cpu/cpuhotplug.py avocado-misc-tests/cpu/cpuhotplug.py.data/cpuhotplug.yaml
 avocado-misc-tests/io/net/htx_nic_devices.py:HtxNicTest.test_check avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
 
 avocado-misc-tests/memory/memtester.py avocado-misc-tests/memory/memtester.py.data/memtester.yaml


### PR DESCRIPTION
cpustress test is now cpuhotplug, so reflected the name in all test buckets