### PR TITLE
Update regression.cfg to take --boot options

### DIFF
--- a/config/tests/guest/libvirt/regression.cfg
+++ b/config/tests/guest/libvirt/regression.cfg
@@ -37,6 +37,9 @@ vcpu_threads = 4
 vcpu_sockets = 1
 # 32G
 mem = 32768
+kernel_args = "<kernel_args>"
+kernel = "/boot/vmlinuz-<kernel_version>"
+initrd = "/boot/initramfs-<kernel_version>.img"
 
 variants:
     - guest_regression:


### PR DESCRIPTION
### Update regression.cfg to take --boot options
Add the following boot parameters to boot into guest having upstream/custom kernel
1. kernel_args: kernel commandline arguments
2. kernel: vmlinux path in host
3. initrd: initramfs image path in host

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)