### PR TITLE
libvirt-mem: Fixing hotplug attach device suite

### DIFF
--- a/config/tests/guest/libvirt/regression.cfg
+++ b/config/tests/guest/libvirt/regression.cfg
@@ -353,13 +353,17 @@ variants:
                         only virsh.attach_detach_disk.attach_disk.error_test.no_vm_name,virsh.attach_detach_disk.attach_disk.normal_test.host_block_vm_id,virsh.attach_detach_disk.detach_disk.error_test.no_vm_name,virsh.attach_detach_disk.detach_disk.normal_test.host_block_vm_id
                     - change-media:
                         only virsh.change_media.cdrom_test.scsi_.positive_test.eject.none.running_guest
+                    - delete_guest:
+                        only remove_guest.without_disk
+                    - import:
+                        vcpu = 4
+                        smp = 4
+                        vcpu_cores = 4
+                        vcpu_threads = 1
+                        vcpu_sockets = 1
+			mem = 4096
+                        only unattended_install.import.import.default_install.aio_native
                     - memory:
-                        max_mem_rt = 67108864
-                        max_mem = 33554432
-                        vcpu = 32
-                        numa_cells = "{'id':'0','cpus':'0-31','memory':'33554432','unit':'KiB'}"
-                        test_dom_xml = "no"
-                        tg_size = 8388608
                         only libvirt_mem.positive_test,libvirt_mem.negative_test
                         no libvirt_mem.positive_test.hugepages
                     - cpu:


### PR DESCRIPTION
### libvirt-mem: Fixing hotplug attach device tests

Removing the memory parameters to take the default parameters from subtest cfg
Add cpu and other topology values to match the libvirt mem subtest script

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)