### PR TITLE
Aligning the guest names with the new polkit rules

### DIFF
--- a/config/tests/guest/libvirt/backuprestore.cfg
+++ b/config/tests/guest/libvirt/backuprestore.cfg
@@ -1,8 +1,8 @@
 include tests-shared.cfg
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 #Network
 nettype = bridge
 netdst=virbr0

--- a/config/tests/guest/libvirt/cpu.cfg
+++ b/config/tests/guest/libvirt/cpu.cfg
@@ -1,8 +1,8 @@
 include tests-shared.cfg
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 nettype = bridge
 netdst=virbr0
 display = 'nographic'

--- a/config/tests/guest/libvirt/install.cfg
+++ b/config/tests/guest/libvirt/install.cfg
@@ -2,8 +2,8 @@ include tests-shared.cfg
 
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 #Network
 nettype = bridge
 netdst = virbr0

--- a/config/tests/guest/libvirt/lifecycle.cfg
+++ b/config/tests/guest/libvirt/lifecycle.cfg
@@ -1,8 +1,8 @@
 include tests-shared.cfg
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 # Network
 nettype = bridge
 netdst=virbr0

--- a/config/tests/guest/libvirt/maxconfig.cfg
+++ b/config/tests/guest/libvirt/maxconfig.cfg
@@ -1,8 +1,8 @@
 include tests-shared.cfg
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 nettype = bridge
 netdst=virbr0
 # Using Text mode of installation

--- a/config/tests/guest/libvirt/memory.cfg
+++ b/config/tests/guest/libvirt/memory.cfg
@@ -1,8 +1,8 @@
 include tests-shared.cfg
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 #Network
 nettype = bridge
 netdst=virbr0

--- a/config/tests/guest/libvirt/migrate.cfg
+++ b/config/tests/guest/libvirt/migrate.cfg
@@ -4,8 +4,8 @@ disk_target = sda
 setup_local_nfs = yes
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 migrate_main_vm = "${main_vm}"
 
 # Network

--- a/config/tests/guest/libvirt/migrate_stress.cfg
+++ b/config/tests/guest/libvirt/migrate_stress.cfg
@@ -4,8 +4,8 @@ disk_target = sda
 setup_local_nfs = yes
 username = root
 password = 123456
-main_vm = "virt-tests-vm1"
-vms = "virt-tests-vm1 virt-tests-vm2 virt-tests-vm3 virt-tests-vm4 virt-tests-vm5 virt-tests-vm6 virt-tests-vm7 virt-tests-vm8 virt-tests-vm9 virt-tests-vm10"
+main_vm = "avocado-vt-vm1"
+vms = "avocado-vt-vm1 avocado-vt-vm2 avocado-vt-vm3 avocado-vt-vm4 avocado-vt-vm5 avocado-vt-vm6 avocado-vt-vm7 avocado-vt-vm8 avocado-vt-vm9 avocado-vt-vm10"
 
 # Network
 nettype = bridge

--- a/config/tests/guest/libvirt/network.cfg
+++ b/config/tests/guest/libvirt/network.cfg
@@ -1,8 +1,8 @@
 include tests-shared.cfg
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 #Network
 nettype = bridge
 netdst=virbr0

--- a/config/tests/guest/libvirt/pci_passthrough.cfg
+++ b/config/tests/guest/libvirt/pci_passthrough.cfg
@@ -1,8 +1,8 @@
 include tests-shared.cfg
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 #Network
 nettype = bridge
 netdst=virbr0

--- a/config/tests/guest/libvirt/ras.cfg
+++ b/config/tests/guest/libvirt/ras.cfg
@@ -1,8 +1,8 @@
 include tests-shared.cfg
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 #Network
 nettype = bridge
 netdst=virbr0

--- a/config/tests/guest/libvirt/regression.cfg
+++ b/config/tests/guest/libvirt/regression.cfg
@@ -1,8 +1,8 @@
 include tests-shared.cfg
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 # Network
 nettype = bridge
 netdst=virbr0

--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -1,8 +1,8 @@
 include tests-shared.cfg
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 #Network
 nettype = bridge
 netdst=virbr0

--- a/config/tests/guest/libvirt/sanity_dev.cfg
+++ b/config/tests/guest/libvirt/sanity_dev.cfg
@@ -1,8 +1,8 @@
 include tests-shared.cfg
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 #Network
 nettype = bridge
 netdst=virbr0

--- a/config/tests/guest/libvirt/short_sanity.cfg
+++ b/config/tests/guest/libvirt/short_sanity.cfg
@@ -1,8 +1,8 @@
 include tests-shared.cfg
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 #Network
 nettype = bridge
 netdst=virbr0

--- a/config/tests/guest/libvirt/storage.cfg
+++ b/config/tests/guest/libvirt/storage.cfg
@@ -1,8 +1,8 @@
 include tests-shared.cfg
 username = root
 password = 123456
-main_vm = virt-tests-vm1
-vms = virt-tests-vm1
+main_vm = avocado-vt-vm1
+vms = avocado-vt-vm1
 #Network
 nettype = bridge
 netdst=virbr0


### PR DESCRIPTION
Description: Polkit rules have got expanded and it is expecting the guest name should be "avocado-vt-vm1". If we provide any other name for the domain other than "avocado-vt-vm1", the tests are getting failed. So modifying the name given to domain to align with that of upstream and community expectations.

Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>
