### PR TITLE
NIC: inputfile create fails due to hard link issue

### DIFF
--- a/lib/pci.py
+++ b/lib/pci.py
@@ -307,8 +307,8 @@ def get_interfaces_in_pci_address(pci_address, pci_class):
     if not pci_class or not os.path.isdir(pci_class_path):
         return ""
     return [interface for interface in os.listdir(pci_class_path)
-            if pci_address in os.readlink(os.path.join(pci_class_path,
-                                                       interface))]
+            if os.path.islink(os.path.join(pci_class_path, interface)) and pci_address \
+                              in os.readlink(os.path.join(pci_class_path, interface))]
 
 
 def get_pci_class_name(pci_address):


### PR DESCRIPTION
while creating inputfile for network devices the script fails at get_interfaces_in_pci_address() to fetch pci interface name.

This patch make sures the hard-links are ignored and only the symlinks are checked for pci address