### PR TITLE
NIC: add interfaces parameter for network bucket

### DIFF
--- a/config/wrapper/pci_input.conf
+++ b/config/wrapper/pci_input.conf
@@ -94,14 +94,18 @@ module = driver
 
 [io_network_fvt]
 interface = interfaces:0
+interfaces = interfaces:all
 host_interfaces = interfaces:all
 pci_device,functions:0
+pci_devices = functions:all
 module = driver
 
 [io_ib_fvt]
 interface = interfaces:0
+interfaces = interfaces:all
 host_interfaces = interfaces:all
 pci_device,functions:0
+pci_devices = functions:all
 module = driver
 
 [io_raid_fvt]


### PR DESCRIPTION
All tests which requires more than 1  interface as input needs mutli interfaces as in put param, as per the input file template