### PR TITLE
SRIOV support to create dynamic inputfile

### DIFF
--- a/config/wrapper/pci_input.conf
+++ b/config/wrapper/pci_input.conf
@@ -96,8 +96,19 @@ module = driver
 interface = interfaces:0
 interfaces = interfaces:all
 host_interfaces = interfaces:all
-pci_device,functions:0
+bond_interfaces = interfaces:all
+pci_device = functions:0
 pci_devices = functions:all
+module = driver
+
+[io_nic_sriov_fvt]
+interface = interfaces:0
+interfaces = interfaces:all
+host_interfaces = interfaces:all
+bond_interfaces = interfaces:all
+pci_device = functions:0
+pci_devices = functions:all
+host_public_ip = public_interface_ip
 module = driver
 
 [io_vnic_fvt]

--- a/lib/pci.py
+++ b/lib/pci.py
@@ -633,6 +633,26 @@ def get_secondary_ioa(primary_ioa):
             return ioa_detail['ioa']
     return ''
 
+def is_sriov(pci_address):
+    """
+    Check if interface is a SRIOV virtual interface.
+
+    This method checks if the interface is SRIOV logical interf
+ace or not.
+
+    rtype: bool
+    """
+    iface_name = get_nics_in_pci_address(pci_address)[0]
+    if not os.path.isfile('/sys/class/net/%s/device/vpd' % iface_name):
+        raise NWException("Network interface sysfs file does not exists")
+    cmd = '/sys/class/net/%s/device/vpd' % iface_name
+    with open(cmd, 'rb') as vpdfile:
+        vpdlines = vpdfile.read().split()
+        for vpd in vpdlines:
+            if b'VF' in vpd and vpd.endswith(b'SN'):
+                return True
+    return False
+
 
 def pci_info(pci_addrs, pci_type='', pci_blocklist='', type_blocklist=''):
     """

--- a/pci_info.py
+++ b/pci_info.py
@@ -24,6 +24,7 @@ import shutil
 import os
 import sys
 import configparser
+from lib.pci import is_sriov
 from lib.logger import logger_init
 from lib.helper import is_rhel8
 
@@ -216,6 +217,11 @@ def create_config(interface_details, config_type):
                 new_cfg = "io_%s_rhel8_%s_fvt" % (pci['adapter_type'], cfg_name)
                 inputfile = "%s/io_%s_rhel8_input.txt" % (
                     BASE_INPUTFILE_PATH, pci['adapter_type'])
+            elif pci['adapter_type'] == 'network' and is_sriov(pci[
+'pci_root']):
+                orig_cfg = "io_nic_sriov_fvt"
+                new_cfg = "io_nic_sriov_%s_fvt" % cfg_name
+                inputfile = "%s/io_nic_sriov_input.txt" % BASE_INPUTFILE_PATH
             else:
                 orig_cfg = "io_%s_fvt" % pci['adapter_type']
                 new_cfg = "io_%s_%s_fvt" % (pci['adapter_type'], cfg_name)


### PR DESCRIPTION
Add support for SRIOV pci interface

The code will help create dynamic input file and cfg file for pci base SRIOV logical devices based on the template created in pci conf

lib/pci: added API to check if the device is sriov, given method returns True if the given pci addr is of SRIOV device