### PR TITLE
Removed Feature: virDomainQemuAttach API

### DIFF
--- a/config/tests/guest/libvirt/memory.cfg
+++ b/config/tests/guest/libvirt/memory.cfg
@@ -84,6 +84,7 @@ variants:
     - guest_libvirt_hooks:
         only libvirt_hooks
         no libvirt_hooks.virsh_attach
+        no libvirt_hooks.vm.virsh_attach
     - guest_hugepage:
         only libvirt_hugepage
         no libvirt_hugepage.contrast.with_mb.trans_disable.static_nonzero.mount_hugetlbfs


### PR DESCRIPTION
Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>

Since libvirt v5.5.0(2019-07-02) qemu: Remove support for virDomainQemuAttach and virConnectDomainXMLFromNative APIs(https://libvirt.org/news.html).


```
# virsh qemu-attach 536328
error: Failed to attach to pid 536328
error: this function is not supported by the connection driver: virDomainQemuAttach
```