### PR TITLE
Update backuprestore.cfg to fix parameter

### DIFF
--- a/config/tests/guest/libvirt/backuprestore.cfg
+++ b/config/tests/guest/libvirt/backuprestore.cfg
@@ -45,48 +45,59 @@ variants:
         only unattended_install.import.import.default_install.aio_native
 
     - guest_backuprestore:
-        only virsh.snapshot_dumpxml,virsh.snapshot_par_cur,virsh.snapshot_disk,virsh.snapshot_create_as
-        #Skipping qed 98 test cases ,as these are supported only for libvirt having version 1.1.0
-        no virsh.snapshot_disk..attach_img_qed
-        #gluster not supported on HOST OS
-        no virsh.snapshot_disk.no_delete.positive_test.no_pool.network_disk
-        no virsh.snapshot_disk.no_delete.negative_test.no_pool.network_disk
-        #Skipping test case due to bug (https://bugzilla.redhat.com/show_bug.cgi?id=1083345)
-        no virsh.snapshot_disk.delete_test.positive_test.no_pool.attach_img_qcow2.snapshot_from_xml.disk_internal.memory_no
-        no virsh.snapshot_disk.delete_test.positive_test.pool_vol
-        no virsh.snapshot_disk.no_delete.positive_test.no_pool.attach_img_qcow2.snapshot_from_xml.disk_internal.memory_no
-        no virsh.snapshot_disk.no_delete.positive_test.pool_vol.dir_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_no
-        no virsh.snapshot_disk.no_delete.positive_test.pool_vol.dir_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_no
-        no virsh.snapshot_disk.no_delete.positive_test.pool_vol.netfs_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_no
-        no virsh.snapshot_disk.no_delete.positive_test.pool_vol.netfs_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_no
-        no virsh.snapshot_disk.no_delete.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_no
-        no virsh.snapshot_disk.no_delete.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_no
-        #Blocked by bug 152314
-        no virsh.snapshot_create_as..file_disk.no_snapshot_attr.disk_only_spec
-        no virsh.snapshot_create_as..file_disk.no_snapshot_attr.check_libvirtd_log
-        no virsh.snapshot_create_as..file_disk.no_snapshot_attr.quiesce_with_diskonly.with_diskspec
-        no virsh.snapshot_create_as..file_disk.no_snapshot_attr.live_memspec.compress_default
-        no virsh.snapshot_create_as..file_disk.no_snapshot_attr.live_memspec.compress_format.raw
-        no virsh.snapshot_create_as..file_disk.no_snapshot_attr.live_memspec.compress_format.xz
-        no virsh.snapshot_create_as..file_disk.no_snapshot_attr.live_memspec.compress_format.lzop
-        no virsh.snapshot_create_as..file_disk.no_snapshot_attr.live_memspec.compress_format.gzip
-        no virsh.snapshot_create_as..file_disk.no_snapshot_attr.live_memspec.compress_format.bzip2
-        no virsh.snapshot_create_as..file_disk.no_snapshot_attr.no_metadata_with_memspec
-        no virsh.snapshot_create_as..file_disk.no_snapshot_attr.reuse_external
-        no virsh.snapshot_create_as..file_disk.no_snapshot_attr.multi_disk_external
-        no virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.name_with_double_dash
-        no virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.quiesce_with_diskonly.no_diskspec
-        no virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.atomic_with_diskonly
-        no virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.no_metadata
-        no virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.no_metadata_with_diskonly
-        no virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.multi_snapshots
-        no virsh.snapshot_create_as.positive_tests.non_acl.file_disk.with_snapshot_attr.disk_only_spec
-        no virsh.snapshot_create_as..quiesce_without_diskonly
-        no virsh.snapshot_create_as.positive_tests.disk_only_spec
-        no virsh.snapshot_create_as.positive_tests.reuse_external
-        no virsh.snapshot_create_as.positive_tests.multi_snapshots
-        no virsh.snapshot_create_as..gluster
-        no virsh.snapshot_disk.delete_test
-        
+        variants:
+            - snapshot:
+                only virsh.snapshot_dumpxml,virsh.snapshot_par_cur,virsh.snapshot_disk,virsh.snapshot_create_as
+                # Skipping qed 98 test cases ,as these are supported only for libvirt having version 1.1.0
+                no virsh.snapshot_disk..attach_img_qed
+                # Gluster not supported on HOST OS
+                no virsh.snapshot_disk.no_delete.positive_test.no_pool.network_disk
+                no virsh.snapshot_disk.no_delete.negative_test.no_pool.network_disk
+                # Skipping test case due to bug (https://bugzilla.redhat.com/show_bug.cgi?id=1083345)
+                no virsh.snapshot_disk.delete_test.positive_test.no_pool.attach_img_qcow2.snapshot_from_xml.disk_internal.memory_no
+                no virsh.snapshot_disk.delete_test.positive_test.pool_vol
+                no virsh.snapshot_disk.no_delete.positive_test.no_pool.attach_img_qcow2.snapshot_from_xml.disk_internal.memory_no
+                no virsh.snapshot_disk.no_delete.positive_test.pool_vol.dir_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_no
+                no virsh.snapshot_disk.no_delete.positive_test.pool_vol.dir_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_no
+                no virsh.snapshot_disk.no_delete.positive_test.pool_vol.netfs_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_no
+                no virsh.snapshot_disk.no_delete.positive_test.pool_vol.netfs_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_no
+                no virsh.snapshot_disk.no_delete.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_no
+                no virsh.snapshot_disk.no_delete.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_no
+                # Blocked by bug 152314
+                no virsh.snapshot_create_as..file_disk.no_snapshot_attr.disk_only_spec
+                no virsh.snapshot_create_as..file_disk.no_snapshot_attr.check_libvirtd_log
+                no virsh.snapshot_create_as..file_disk.no_snapshot_attr.quiesce_with_diskonly.with_diskspec
+                no virsh.snapshot_create_as..file_disk.no_snapshot_attr.live_memspec.compress_default
+                no virsh.snapshot_create_as..file_disk.no_snapshot_attr.live_memspec.compress_format.raw
+                no virsh.snapshot_create_as..file_disk.no_snapshot_attr.live_memspec.compress_format.xz
+                no virsh.snapshot_create_as..file_disk.no_snapshot_attr.live_memspec.compress_format.lzop
+                no virsh.snapshot_create_as..file_disk.no_snapshot_attr.live_memspec.compress_format.gzip
+                no virsh.snapshot_create_as..file_disk.no_snapshot_attr.live_memspec.compress_format.bzip2
+                no virsh.snapshot_create_as..file_disk.no_snapshot_attr.no_metadata_with_memspec
+                no virsh.snapshot_create_as..file_disk.no_snapshot_attr.reuse_external
+                no virsh.snapshot_create_as..file_disk.no_snapshot_attr.multi_disk_external
+                no virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.name_with_double_dash
+                no virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.quiesce_with_diskonly.no_diskspec
+                no virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.atomic_with_diskonly
+                no virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.no_metadata
+                no virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.no_metadata_with_diskonly
+                no virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.multi_snapshots
+                no virsh.snapshot_create_as.positive_tests.non_acl.file_disk.with_snapshot_attr.disk_only_spec
+                # Needs change of parameter, running it later
+                no virsh.snapshot_create_as.negative_tests.network_disk.iscsi.device_lun
+                no virsh.snapshot_create_as..quiesce_without_diskonly
+                no virsh.snapshot_create_as.positive_tests.disk_only_spec
+                no virsh.snapshot_create_as.positive_tests.reuse_external
+                no virsh.snapshot_create_as.positive_tests.multi_snapshots
+                no virsh.snapshot_create_as..gluster
+                no virsh.snapshot_disk.delete_test
+
+            # Default virtio (virtio-blk) is not supported for iscsi emulation
+            # Hence, change it to scsi bus
+            - snapshot_create_as.negative_tests.network_disk.iscsi.device_lun:
+                disk_target_bus = "scsi"
+                disk_target = "sdb"
+                only virsh.snapshot_create_as.negative_tests.network_disk.iscsi.device_lun
+
     - guest_remove:
         only remove_guest.without_disk


### PR DESCRIPTION
- The virsh.snapshot_create_as.negative_tests.network_disk.iscsi.device_lun requires bus as "scsi" and target as "sdb"
- The default bus "virtio" (virtio-blk) and default disk "sda" are leading to error since virtio-blk is not support for iscsi emulation and default disk sda is leading to duplicacy.
- Hence, adding the parameters seperately only for this particular scenario is required
```
            - snapshot_create_as.negative_tests.network_disk.iscsi.device_lun:
                disk_target_bus = "scsi"
                disk_target = "sdb"
                only virsh.snapshot_create_as.negative_tests.network_disk.iscsi.device_lun
```
Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)
