### PR TITLE
Add multivm-stress.cfg config file

### DIFF
--- a/config/tests/guest/libvirt/multivm_stress.cfg
+++ b/config/tests/guest/libvirt/multivm_stress.cfg
@@ -1,0 +1,109 @@
+include tests-shared.cfg
+
+username = root
+password = 123456
+main_vm = vm1
+nettype = bridge
+netdst=virbr0
+
+# Using Text mode of installation
+display = 'nographic'
+
+take_regular_screendumps = no
+keep_screendumps_on_error = no
+keep_screendumps = no
+store_vm_register = no
+virt_install_binary = /usr/bin/virt-install
+qemu_img_binary = /usr/bin/qemu-img
+qemu_binary = /usr/bin/qemu-system-ppc64
+emulator_path = /usr/bin/qemu-system-ppc64
+use_os_variant=yes
+hvm_or_pv = hvm
+machine_type = pseries
+only bridge
+no xen, lxc, esx, ovmf
+
+# Filterout unwanted disk types
+no ide,xenblk,lsi_scsi,ahci,sd
+no qed,qcow2v3,raw_dd,vmdk, usb2
+no e1000-82540em,e1000-82545em,e1000-82544gc,xennet,nic_custom
+
+only no_virtio_rng
+only smp2
+only no_9p_export
+only no_pci_assignable
+only (image_backend=filesystem)
+only smallpages
+only virtio_net
+only virtio_scsi
+only qcow2
+
+# Guest Kernel parameters
+kernel_args = "<kernel_args>"
+kernel = "/boot/vmlinuz-<kernel_version>"
+initrd = "/boot/initramfs-<kernel_version>.img"
+
+variants:
+    - guest_scalability:
+        main_vm = vm1
+        create_vm_libvirt = yes
+        kill_vm_libvirt = yes
+        env_cleanup = yes
+        backup_image_before_testing = no
+        restore_image_after_testing = no
+
+        vcpu_maxcpus_vm1 = 16
+        vcpu_cores_vm1 = 2
+        vcpu_sockets_vm1 = 8
+        vcpu_threads_vm1 = 1
+        vcpu_dies_vm1 = 1
+        mem_vm1 = 10000
+        smp_vm1 = 8
+        stress_args_vm1 = --cpu 4 --vm 2 --vm-bytes 256M
+
+        vcpu_maxcpus_vm2 = 16
+        vcpu_cores_vm2 = 2
+        vcpu_sockets_vm2 = 8
+        vcpu_threads_vm2 = 1
+        vcpu_dies_vm2 = 1
+        mem_vm2 = 10000
+        smp_vm2 = 8
+	stress_type_vm2 = htxcmdline_in_vms
+        stress_cmds_htxcmdline_vm2 = "htxcmdline"
+        htxcmdline_args_vm2 = "-run -mdt mdt.mem"
+        download_url_htxcmdline_vm2 = "http:://<>"
+        make_cmds_htxcmdline_vm2 = "rpm -i htxrhel9-679-LE.ppc64le.rpm"
+
+        vcpu_maxcpus_vm3 = 16
+        vcpu_cores_vm3 = 2
+        vcpu_sockets_vm3 = 8
+        vcpu_threads_vm3 = 1
+        vcpu_dies_vm3 = 1
+        mem_vm3 = 10000
+        smp_vm3 = 8
+        stress_args_vm3 = --cpu 4 --vm 2 --vm-bytes 256M
+
+        vcpu_maxcpus_vm4 = 16
+        vcpu_cores_vm4 = 2
+        vcpu_sockets_vm4 = 8
+        vcpu_threads_vm4 = 1
+        vcpu_dies_vm4 = 1
+        mem_vm4 = 10000
+        smp_vm4 = 8
+	stress_type_vm4 = htxcmdline_in_vms
+        stress_cmds_htxcmdline_vm4 = "htxcmdline"
+        htxcmdline_args_vm4 = "-run -mdt mdt.all"
+        download_url_htxcmdline_vm4 = "http:://<>"
+        make_cmds_htxcmdline_vm4 = "rpm -i htxrhel9-679-LE.ppc64le.rpm"
+
+        guest_stress = yes
+	stress_time = 172800
+        stress_itrs = 10
+        itr_sleep_time = 30
+        stress_events = "reboot"
+        host_stress = no
+        verify_guest_dmesg = no
+        vms = "vm1 vm2 vm3 vm4"
+        debug_dir = "/home/kvmci/kvmci-multivm-project/results/latest/"
+
+	only multivm_cpustress.custom_host_events.custom_vm_events


### PR DESCRIPTION
### Add multivm-stress.cfg config file

This multivm config file allows us to test multivm scenarios.
- Running 4 VMs
- Running stress and HTX in the VMs
- Adding different stress/events parameters

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)