### PR TITLE
Add lop-devops/avocado-vt link to KVMCI branch

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -4,7 +4,7 @@
 # ('avocado-framework', 80.0)  -- Installs specificed version, make sure you change other entries aswell
 # ('avocado-framework', 'git+https://github.com/avocado-framework/avocado.git') -- Install version from the given git repo
 base = [('avocado-framework', ''), ('avocado-framework-plugin-varianter-yaml-to-mux', '')]
-kvm = [('avocado-framework-plugin-vt', 'git+https://github.com/avocado-framework/avocado-vt.git')]
+kvm = [('avocado-framework-plugin-vt', 'git+https://github.com/lop-devops/avocado-vt.git@KVMCI')]
 optional = [('avocado-framework-plugin-result-html', '')]
 
 [tests]


### PR DESCRIPTION
### Add lop-devops/avocado-vt link to KVMCI branch

Update the env.conf file to add lop-devops/avocado-vt repo link to 
bootstrap KVMCI related changes in KVMCI branch

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)