### PR TITLE
Fix pip based installation in helper

### DIFF
--- a/lib/helper.py
+++ b/lib/helper.py
@@ -21,6 +21,7 @@ import sys
 import shutil
 import stat
 import platform
+import importlib.metadata
 
 from .logger import logger_init
 
@@ -218,6 +219,11 @@ class PipMagager:
         # Check for pip if not attempt install and proceed
         cmd = "%s --help >/dev/null 2>&1||(curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python%s ./get-pip.py)" % (self.pip_cmd, sys.version_info[0])
         runcmd(cmd, err_str='Unable to install pip3')
+
+        # Get pip version
+        pip_version_split = importlib.metadata.version(f"pip").split(".")
+        self.pip_vmajor, self.pip_vminor = int(pip_version_split[0]), int(pip_version_split[1])
+
         self.uninstallitems = base_fw + opt_fw + kvm_fw
         if enable_kvm:
             self.installitems = self.uninstallitems
@@ -243,15 +249,18 @@ class PipMagager:
         else:
             pip_installcmd = '%s install -U' % self.pip_cmd
         for package in self.install_packages:
-            cmd = '%s %s --break-system-packages' % (pip_installcmd, package)
+            cmd = '%s %s' % (pip_installcmd, package)
+            if (self.pip_vmajor > 23) or (self.pip_vmajor == 23 and self.pip_vminor >= 1):
+                cmd = cmd + ' --break-system-packages' # --break-system-packages introduced in pip 23.1
             runcmd(cmd,
                    err_str='Package installation via pip failed: package  %s' % package,
                    debug_str='Installing python package %s using pip' % package)
 
     def uninstall(self):
         for package in self.uninstall_packages:
-            cmd = "%s uninstall %s --break-system-packages -y \
-                    --disable-pip-version-check" % (self.pip_cmd, package)
+            cmd = '%s uninstall %s -y --disable-pip-version-check' % (self.pip_cmd, package)
+            if (self.pip_vmajor > 23) or (self.pip_vmajor == 23 and self.pip_vminor >= 1):
+                cmd = cmd + ' --break-system-packages' # --break-system-packages introduced in pip 23.1
             runcmd(cmd, ignore_status=True,
                    err_str="Error in removing package: %s" % package,
                    debug_str="Uninstalling %s" % package)


### PR DESCRIPTION
Support --break-system-packages, introduced in pip 23.1, ensuring graceful handling for compatibility.
https://peps.python.org/pep-0668/

Fixes: d647422265f0 ("Fix for pip issue with Ubuntu") https://github.com/lop-devops/tests/commit/d647422265f05fd38819f2702f0c868d85362677

Reviewed-by: Narasimhan V <narasimhan.v@amd.com>
Reviewed-and-tested-by: Srikanth Aithal <srikanth.aithal@amd.com>