### PR TITLE
Fix branch checkout for tests

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -214,7 +214,7 @@ def get_repo(repo, basepath):
         branch = "master"
     else:
         branch = repo[1]
-    cmd_update = "b=%s;git reset --hard && git checkout master && git remote update && (git branch|grep $b||(git checkout $b && git switch -c $b))" % branch
+    cmd_update = "b=%s;git reset --hard && git checkout master && git remote update && (git branch | grep -w $b && (git switch $b && git pull origin $b --rebase) || (git fetch origin && git switch -c $b origin/$b) || echo \"Error: Could not sync with origin/$b\")" % branch
     repo_name = repo[0].split('/')[-1].split('.git')[0]
     repo_path = os.path.join(basepath, repo_name)
     cmd_clone = "git clone %s %s" % (repo[0], repo_path)


### PR DESCRIPTION
Currently branch checkout fails for tests. This
commit fixes it.

Update in config/wrapper/env.conf the location of tests, have taken avocado-misc-tests for example with branch name other than the default one.

```
[tests]
# Usage Examples:
# ('https://github.com/avocado-framework-tests/avocado-misc-tests.git', '2.0') -- Clones tagged version 2.0 of test repository
name = [('https://github.com/avocado-framework-tests/avocado-misc-tests.git', 'py2-lts')]
```

Before fix:

```
# python3 ./avocado-setup.py --bootstrap
08:31:20 INFO    : Check for environment
08:31:20 INFO    : Cleaning the Environment
08:31:21 INFO    : Bootstrapping Framework
08:31:21 INFO    :      1. Creating Avocado Config
08:31:21 INFO    :      2. Installing Avocado Framework
08:31:24 INFO    :      3. Cloning/Updating the repo: avocado-misc-tests with branch py2-lts under tests/tests/avocado-misc-tests
08:31:28 ERROR   : Failed to clone/update avocado-misc-tests repository: Cloning into 'tests/tests/avocado-misc-tests'...
HEAD is now at 8fd924f2 Merge pull request #2968 from vaishnavibhat/iperf_firewall
Already on 'master'
Your branch is up to date with 'origin/master'.
Switched to a new branch 'py2-lts'
branch 'py2-lts' set up to track 'origin/py2-lts'.
fatal: a branch named 'py2-lts' already exists
```

After fix:
```
# python3 ./avocado-setup.py --bootstrap
08:33:40 INFO    : Check for environment
08:33:40 INFO    : Cleaning the Environment
08:33:42 INFO    : Bootstrapping Framework
08:33:42 INFO    :      1. Creating Avocado Config
08:33:42 INFO    :      2. Installing Avocado Framework
08:33:45 INFO    :      3. Cloning/Updating the repo: avocado-misc-tests with branch py2-lts under tests/tests/avocado-misc-tests

# cd tests/avocado-misc-tests/;git status
On branch py2-lts
Your branch is up to date with 'origin/py2-lts'.

nothing to commit, working tree clean
```