### PR TITLE
Print Testsummary for testsuites and testruns post results

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -94,7 +94,7 @@ class TestSuite():
         self.test = test
         self.mux = mux
         self.args = args
-        self.run = "Not_Run"
+        self.run = Testsuite_status.Not_Run.value
         self.runsummary = None
         self.runlink = None
         if use_test_dir:
@@ -401,13 +401,13 @@ def run_test(testsuite, avocado_bin, nrunner):
         status = os.system(cmd)
         status = int(bin(int(status))[2:].zfill(16)[:-8], 2)
         if status >= 2:
-            testsuite.runstatus("Not_Run", "Command execution failed")
+            testsuite.runstatus(Testsuite_status.Not_Run.value, "Command execution failed")
             count_testsuites_status[Testsuite_status.Not_Run.value] += 1
             return
     except Exception as error:
         logger.error("Running testsuite %s failed with error\n%s",
                      testsuite.name, error)
-        testsuite.runstatus("Not_Run", "Command execution failed")
+        testsuite.runstatus(Testsuite_status.Not_Run.value, "Command execution failed")
         count_testsuites_status[Testsuite_status.Not_Run.value] += 1
         return
     logger.info('')
@@ -423,10 +423,10 @@ def run_test(testsuite, avocado_bin, nrunner):
                 count_result[state] += int(result_state[state])
                 result_link += "| %s %s |" % (state.upper(),
                                               str(result_state[state]))
-        testsuite.runstatus("Run", "Successfully executed", result_link)
+        testsuite.runstatus(Testsuite_status.Run.value, "Successfully executed", result_link)
         count_testsuites_status[Testsuite_status.Run.value] += 1
     else:
-        testsuite.runstatus("Not_Run", "Unable to find job log file")
+        testsuite.runstatus(Testsuite_status.Not_Run.value, "Unable to find job log file")
         count_testsuites_status[Testsuite_status.Not_Run.value] += 1
     return
 
@@ -751,7 +751,7 @@ if __name__ == '__main__':
                     Testsuites[test_suite] = TestSuite(test_suite, outputdir,
                                                        args.vt_type,
                                                        use_test_dir=args.testdir)
-                    Testsuites[test_suite].runstatus("Cant_Run",
+                    Testsuites[test_suite].runstatus(Testsuite_status.Cant_Run.value,
                                                      "Config file not present")
                     count_testsuites_status[Testsuite_status.Cant_Run.value] += 1
                     Testsuites_list.append(test_suite)
@@ -775,14 +775,14 @@ if __name__ == '__main__':
                                                    use_test_dir=args.testdir)
                 Testsuites_list.append(str(test_suite))
                 if not Testsuites[test_suite].config():
-                    Testsuites[test_suite].runstatus("Cant_Run",
+                    Testsuites[test_suite].runstatus(Testsuite_status.Cant_Run.value,
                                                      "Config file not present")
                     count_testsuites_status[Testsuite_status.Cant_Run.value] += 1
                     continue
         # Run Tests
         count_testsuites_status[Testsuite_status.Total.value] = len(Testsuites_list)
         for test_suite in Testsuites_list:
-            if not Testsuites[test_suite].run == "Cant_Run":
+            if not Testsuites[test_suite].run == Testsuite_status.Cant_Run.value:
                 run_test(Testsuites[test_suite], avocado_bin, args.nrunner)
                 if args.interval:
                     time.sleep(int(args.interval))


### PR DESCRIPTION
1.  Print final count summary after test run
2. Add summary of testsuites ran
3. Use Testsuite_status enum instead of hardcoded status strings

Example: 
```
TestSuite                                                                                TestRun    Summary

host_sanity_fast_linsched                                                                Run        Successfully executed
/home/amd/Ayush/Avocadotests/results/job-2025-04-12T13.29-b585cfe/job.log
| PASS 1 || CANCEL 0 || ERRORS 0 || FAILURES 0 || SKIP 0 || WARN 0 || INTERRUPT 0 |

host_sanity_fast_numactl_Numactl_test_localalloc_numa_fc                                 Run        Successfully executed
/home/amd/Ayush/Avocadotests/results/job-2025-04-12T13.29-6d7be4d/job.log
| PASS 0 || CANCEL 1 || ERRORS 0 || FAILURES 0 || SKIP 0 || WARN 0 || INTERRUPT 0 |

host_sanity_fast2_sanity_fast2                                                           Not_Run    Command execution failed


host_sanity_fast3                                                                        Cant_Run   Config file not present


Test suites status:

TOTAL                4
RUN                  2
NOT_RUN              1
CANT_RUN             1

Final count summary for tests run:

TOTAL                2
PASS                 1
CANCEL               1
ERRORS               0
FAILURES             0
SKIP                 0
WARN                 0
INTERRUPT            0
```