### PR TITLE
Fix package install

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -152,8 +152,16 @@ def env_check(enable_kvm):
         if packages != '':
             env_deps = packages.split(',')
     for dep in env_deps:
-        if helper.runcmd(cmd_pat % dep, ignore_status=True)[0] != 0:
-            not_found.append(dep)
+        if(dep[-1] == "$"):
+            #Substrings
+            formatted_dep=dep[:-1]
+            original_dep = formatted_dep
+        else:
+            #Absoulute strings
+            formatted_dep = f"^{dep}/"
+            original_dep = dep
+        if helper.runcmd(cmd_pat % formatted_dep, ignore_status=True)[0] != 0:
+            not_found.append(original_dep)
 
     env_deps = []
     # try to check env specific packages

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -123,7 +123,7 @@ def get_env_type(enable_kvm=False):
     if env_type == "NV" and enable_kvm:
         env_type = "kvm"
     if 'ubuntu' in dist:
-        cmd_pat = "dpkg -l|grep  ' %s'"
+        cmd_pat = "apt list --installed | grep -i '%s'"
     else:
         cmd_pat = "rpm -q %s"
     return (env_ver, env_type, cmd_pat)


### PR DESCRIPTION
Introducing a wild character "$", for marking that package_name is not a absolute package name ie substrings.

Also update package check in ubuntu distro to
`apt list --installed | grep -i 'package_name'"
to avoid mischeck of packages uninstalleted package's stale cfg file.

Reported-by: Dheeraj Kumar Srivastava <dheerajkumar.srivastava@amd.com>
Signed-off-by: Ayush Jain <Ayush.jain3@amd.com>