### PR TITLE
config: Update SLES16 Python packages, add pexpect to pip dependencies

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -154,7 +154,7 @@ packages =
 [deps_sles15_kvm]
 packages = tcpdump,qemu
 [deps_sles16]
-packages = gcc,python311-devel,7zip,xz-devel,python311-setuptools,tcpdump,numactl
+packages = gcc,python3-devel,7zip,xz-devel,python3-setuptools,tcpdump,numactl
 [deps_slesbe]
 packages = gcc,python3-devel,xz-devel,python3-setuptools,tcpdump,numactl
 [deps_slesbe_NV]
@@ -173,7 +173,7 @@ packages =
 packages =
 
 [pip-package]
-package = [('configparser',''), ('distlib','')]
+package = [('configparser',''), ('distlib',''), ('pexpect','')]
 
 [script-dir]
 prescriptdir = /etc/avocado/scripts/job/pre.d/


### PR DESCRIPTION
### config: Update SLES16 Python packages and add pexpect to pip dependencies

- Replace python311-* with python3-* packages for SLES16 to maintain consistency
- Add pexpect to pip-package list for enhanced functionality

Signed-off-by: Misbah Anjum N <misanjumn@ibm.com> 