### PR TITLE
Add SLES 16.1 specific package dependencies!

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -155,6 +155,8 @@ packages =
 packages = tcpdump,qemu
 [deps_sles16]
 packages = gcc,python311-devel,7zip,xz-devel,python311-setuptools,tcpdump,numactl
+[deps_sles16_1]
+packages = numa-preplace,gcc,python313-devel,7zip,xz-devel,python313-setuptools,tcpdump,numactl,nfs-client,nfs-kernel-server
 [deps_slesbe]
 packages = gcc,python3-devel,xz-devel,python3-setuptools,tcpdump,numactl
 [deps_slesbe_NV]


### PR DESCRIPTION
Define SLES 16.1 specific packages in [deps_sles16_1] section. These packages are only available or required for SLES 16.1 and will not be installed on other SLES 16.x versions.

Signed-off-by: Anushree-Mathur <anushree.mathur@linux.ibm.com>