### PR TITLE
cfg: Add global kdump RAS params to ras config files

### DIFF
--- a/config/tests/guest/libvirt/ras.cfg
+++ b/config/tests/guest/libvirt/ras.cfg
@@ -49,6 +49,16 @@ vcpu_threads = 1
 vcpu_sockets = 1
 mem = 32768
 
+# Global kdump RAS params
+setup_kdump = no
+guest_upstream_kernel = no
+upstream_kernel_vmlinux = ''
+install_missing_packages = no
+crashkernel_value = 1500M
+crash_dir = /var/crash/
+debug_dir = /home/
+dump_dir = /home/
+
 # Test Variants
 variants:
     - guest_import:

--- a/config/tests/guest/libvirt/ras_p1.cfg
+++ b/config/tests/guest/libvirt/ras_p1.cfg
@@ -49,6 +49,16 @@ vcpu_threads = 1
 vcpu_sockets = 1
 mem = 32768
 
+# Global kdump RAS params
+setup_kdump = no
+guest_upstream_kernel = no
+upstream_kernel_vmlinux = ''
+install_missing_packages = no
+crashkernel_value = 1500M
+crash_dir = /var/crash/
+debug_dir = /home/
+dump_dir = /home/
+
 # Test Variants
 variants:
     - guest_import:

--- a/config/tests/guest/libvirt/ras_p2.cfg
+++ b/config/tests/guest/libvirt/ras_p2.cfg
@@ -49,6 +49,16 @@ vcpu_threads = 1
 vcpu_sockets = 1
 mem = 32768
 
+# Global kdump RAS params
+setup_kdump = no
+guest_upstream_kernel = no
+upstream_kernel_vmlinux = ''
+install_missing_packages = no
+crashkernel_value = 1500M
+crash_dir = /var/crash/
+debug_dir = /home/
+dump_dir = /home/
+
 # Test Variants
 variants:
     - guest_import:

--- a/config/tests/guest/libvirt/ras_p3.cfg
+++ b/config/tests/guest/libvirt/ras_p3.cfg
@@ -49,6 +49,16 @@ vcpu_threads = 1
 vcpu_sockets = 1
 mem = 32768
 
+# Global kdump RAS params
+setup_kdump = no
+guest_upstream_kernel = no
+upstream_kernel_vmlinux = ''
+install_missing_packages = no
+crashkernel_value = 1500M
+crash_dir = /var/crash/
+debug_dir = /home/
+dump_dir = /home/
+
 # Test Variants
 variants:
     - guest_import:


### PR DESCRIPTION
## cfg: Add global kdump RAS params to ras config files

Add the following kdump-related parameters to the global section of ras.cfg, ras_p1.cfg, ras_p2.cfg, and ras_p3.cfg to support the KdumpManager interface in utils_kdump.py:

  - setup_kdump: controls whether kdump setup is performed
  - guest_upstream_kernel: flag for upstream kernel usage
  - upstream_kernel_vmlinux: path to vmlinux for upstream kernels
  - install_missing_packages: controls auto-installation of packages
  - crashkernel_value: reserved memory for crash kernel (1500M)
  - crash_dir: directory where vmcore files are written (/var/crash/)
  - debug_dir: directory for debug artifacts (/home/)
  - dump_dir: directory for dump output (/home/)

All parameters are set to safe/disabled defaults so existing tests are unaffected unless explicitly overridden per test variant.

Signed-off-by: Misbah Anjum N <misanjumn@ibm.com>