### PR TITLE
network: disable tx queue value tests

### DIFF
--- a/config/tests/guest/libvirt/network.cfg
+++ b/config/tests/guest/libvirt/network.cfg
@@ -170,6 +170,8 @@ variants:
                 no virtual_network.iface_options.iface_type.type_user
                 no virtual_network.iface_options.iface_type.type_vhostuser.vhost_dpdk
                 no virtual_network.iface_options.iface_unprivileged_user
+                no type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_driver.driver_tx_queue_size.start_success.right_boundary_value
+                no type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_driver.driver_tx_queue_size.start_success.middle_value
             - net_virsh_attach_detach_interface:
                 only virsh.attach_detach_interface
                 no virsh.attach_detach_interface.normal_test.vm_paused.exist_bridge.domid


### PR DESCRIPTION
TX Queue size above 256 is not supported on power systems unless you're using user agent. Hence, these tests are not valid for our use cases.